### PR TITLE
Remove VS Code settings file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+.vscode/settings.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "cSpell.words": [
-        "covid"
-    ],
-    "cSpell.language": "en,de"
-}


### PR DESCRIPTION
VS Code write in this file, e.g. when a Python interpreter is set. This
causes issues e.g. when rebasing so we remove this file and ignore it.