### PR TITLE
Add id generators for queues and places

### DIFF
--- a/backend/utils/id_generator.py
+++ b/backend/utils/id_generator.py
@@ -1,0 +1,45 @@
+import random
+import time
+from hashlib import sha1
+
+random.seed()
+
+WORDLIST = {
+    'adjective': [
+        'angenehm', 'attraktiv', 'aufmerksam', 'bunt', 'blau', 'charmant',
+        'dankbar', 'edel', 'frei', 'gelb', 'glatt', 'hell', 'ideal', 'jung',
+        'leicht', 'lieb', 'luftig', 'mutig', 'nah', 'neu', 'offen', 'poetisch',
+        'rein', 'rund', 'sicher', 'treu', 'wach', 'warm', 'weich', 'zart',
+        'zentral', 'zivil'
+    ],
+    'noun': [
+        'amulett', 'arm', 'ball', 'baum', 'dach', 'eimer', 'engel', 'film',
+        'foto', 'freiheit', 'haus', 'insel', 'kugel', 'liebe', 'mutter',
+        'maus', 'nase', 'natur', 'obst', 'orgel', 'papier', 'quelle', 'radio',
+        'ritter', 'sand', 'stein', 'uhr', 'vater', 'vogel', 'wasser', 'zahn'
+    ],
+    'verb': [
+        'atmen', 'baden', 'bilden', 'danken', 'deuten', 'essen', 'haben',
+        'heilen', 'hoffen', 'jubeln', 'kreisen', 'lachen', 'leben', 'leuchten',
+        'loben', 'lohnen', 'malen', 'mischen', 'ordnen', 'planen', 'pfeifen',
+        'reden', 'rollen', 'sehen', 'stehen', 'teilen', 'trinken', 'wollen',
+        'zelten'
+    ]
+}
+
+def generate_place_id():
+    """
+    Returns:
+        - String: Human-readable id phrase
+    """
+    return random.choice(WORDLIST['adjective']) + \
+           random.choice(WORDLIST['noun']) + \
+           random.choice(WORDLIST['verb'])
+
+
+def generate_queue_id(queue_name):
+    hasher = sha1()
+    hasher.update(queue_name.encode('utf-8'))
+    name_hash = hasher.hexdigest()[:4] 
+    time_stamp = str(int(time.time()))[-2:]
+    return name_hash + time_stamp

--- a/backend/utils/id_generator.py
+++ b/backend/utils/id_generator.py
@@ -43,3 +43,4 @@ def generate_queue_id(queue_name):
     name_hash = hasher.hexdigest()[:4] 
     time_stamp = str(int(time.time()))[-2:]
     return name_hash + time_stamp
+


### PR DESCRIPTION
This would Close #21.

- To ease communication with patients, the suggestion is to use a random word list to specify **"places" IDs**. Later on this simply can be switched to user defined strings if necessary.
- As we are expecting a relative low number of queues per place, the **queue ID** is generated by concatenating a sha1 hash of the queue name with the epoch seconds.
- After discussing the impact of enumerating entry IDs: Knowledge about the position of a certain (but still anonymous) user in a queue should not lead to privacy concerns. The only concern would be a person claiming to own an ID. For example by showing the open website with the ID to a desk clerk. In case of notifications by push messages the same would hold. Our resolution for **entry IDs** is therefore to use the integer values generated by the database interface.
