### PR TITLE
Implement query for the full queue state

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -17,7 +17,7 @@ db = SQLAlchemy(app)
 db_file = Path(sqlite_location)
 if not db_file.is_file():
     db_file.parent.absolute().mkdir(parents=True, exist_ok=True)
-    from models.slot import Slot
+    from models.entry import Entry
     from models.queue import Queue
     from models.place import Place, generate_default_place
     db.create_all()

--- a/backend/digitales_warten.py
+++ b/backend/digitales_warten.py
@@ -100,7 +100,7 @@ def delete_queue(place_id, queue_id):
     db.session.commit()
     return ''
 
-@app.route('/places/<place_id>/queues/<queue_id>', methods=['POST'])
+@app.route('/places/<place_id>/queues/<queue_id>/entries', methods=['POST'])
 def add_entry(place_id, queue_id):
     place = Place.query.filter_by(id=place_id).first()
     if place is None:

--- a/backend/digitales_warten.py
+++ b/backend/digitales_warten.py
@@ -8,7 +8,7 @@ from app import app, db
 from sqlalchemy import desc
 from models.place import Place
 from models.queue import Queue
-from models.slot import Slot
+from models.entry import Entry
 from utils.id_generator import generate_queue_id, generate_place_id, generate_entry_id
 
 from tornado.log import enable_pretty_logging
@@ -113,10 +113,10 @@ def add_entry(place_id, queue_id):
         abort(400)
     entry_name = data['name']
     entry_id = generate_entry_id(entry_name)
-    largest_previous_slot = db.session.query(Slot).filter_by(queue=queue).order_by(desc(Slot.ticket_number)).limit(1).first()
-    ticket_number = largest_previous_slot.ticket_number + 1 if largest_previous_slot else 1
-    slot = Slot(id=entry_id, name=entry_name, queue=queue, ticket_number=ticket_number)
-    db.session.add(slot)
+    largest_previous_entry = db.session.query(Entry).filter_by(queue=queue).order_by(desc(Entry.ticket_number)).limit(1).first()
+    ticket_number = largest_previous_entry.ticket_number + 1 if largest_previous_entry else 1
+    entry = Entry(id=entry_id, name=entry_name, queue=queue, ticket_number=ticket_number)
+    db.session.add(entry)
     db.session.commit()
     return jsonify(id=entry_id, name=entry_name, ticketNumber=ticket_number)
 

--- a/backend/models/entry.py
+++ b/backend/models/entry.py
@@ -1,6 +1,6 @@
 from app import db
 
-class Slot(db.Model):
+class Entry(db.Model):
     id = db.Column(db.String, primary_key=True)
     queue_id = db.Column(db.String, db.ForeignKey('queue.id'), primary_key=True)
     queue = db.relationship('Queue', backref=db.backref('slots'))
@@ -8,4 +8,4 @@ class Slot(db.Model):
     ticket_number = db.Column(db.Integer)
 
     def __repr__(self):
-        return f'<Slot {id}>'
+        return f'<Entry {id}>'

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -20,19 +20,19 @@ class TestBackendIntegration:
 
     @pytest.fixture
     def entry_id(self, place_id, queue_id):
-        entry_response = requests.post(f'{self.host}/places/{place_id}/queues/{queue_id}',
+        entry_response = requests.post(f'{self.host}/places/{place_id}/queues/{queue_id}/entries',
                                         json={'name': 'TestEntry'})
         return entry_response.json()['id']
 
     @pytest.fixture
     def entry_name(self, place_id, queue_id):
-        entry_response = requests.post(f'{self.host}/places/{place_id}/queues/{queue_id}',
+        entry_response = requests.post(f'{self.host}/places/{place_id}/queues/{queue_id}/entries',
                                         json={'name': 'TestEntryName'})
         return entry_response.json()['name']
 
     @pytest.fixture
     def entry_ticket(self, place_id, queue_id):
-        entry_response = requests.post(f'{self.host}/places/{place_id}/queues/{queue_id}',
+        entry_response = requests.post(f'{self.host}/places/{place_id}/queues/{queue_id}/entries',
                                         json={'name': 'TestEntryTicket'})
         return entry_response.json()['ticketNumber']
 


### PR DESCRIPTION
Closes #20 

This adds the full query of entries, which include their name as information.
This should be discussed again, as we at some point agreed that PII should not be contained in the database and only be handled client side.

Also bug and name fixes from previous commits are included in this PR.