### PR TITLE
WIP [DO NOT MERGE] Add legal notice ("Impressum")

### DIFF
--- a/frontend/public/impressum.html
+++ b/frontend/public/impressum.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Impressum</title>
+</head>
+
+<body>
+  <h1>Impressum</h1>
+
+  <p><i>Angaben gemäß § 5 TMG</i></p>
+  <p>
+    Richard Baumann<br>
+    Koldestraße 8B<br />
+    91052 Erlangen<br />
+  </p>
+  <p>
+    <b>Vertreten durch:</b> Richard Baumann</br>
+    <b>Kontakt:</b> E-Mail: admin at ohaz.engineer
+  </p>
+
+  <p><i>Verantwortlich für den Inhalt nach § 55 Abs. 2 RStV:</i></p>
+  <p>
+    Richard Baumann<br>
+    Koldestraße 8B<br />
+    91052 Erlangen<br />
+  </p>
+
+  <hr/>
+
+  <h2>Haftungsausschluss</h2>
+
+  <h3>Haftung für Inhalte</h3>
+
+  <p>
+    Die Inhalte unserer Seiten wurden mit größter Sorgfalt erstellt. Für
+    die Richtigkeit, Vollständigkeit und Aktualität der Inhalte können wir
+    jedoch keine Gewähr übernehmen. Als Diensteanbieter sind wir gemäß § 7
+    Abs.1 TMG für eigene Inhalte auf diesen Seiten nach den allgemeinen
+    Gesetzen verantwortlich. Nach §§ 8 bis 10 TMG sind wir als
+    Diensteanbieter jedoch nicht verpflichtet, übermittelte oder
+    gespeicherte fremde Informationen zu überwachen oder nach Umständen zu
+    forschen, die auf eine rechtswidrige Tätigkeit hinweisen.
+    Verpflichtungen zur Entfernung oder Sperrung der Nutzung von
+    Informationen nach den allgemeinen Gesetzen bleiben hiervon unberührt.
+    Eine diesbezügliche Haftung ist jedoch erst ab dem Zeitpunkt der
+    Kenntnis einer konkreten Rechtsverletzung möglich. Bei Bekanntwerden
+    von entsprechenden Rechtsverletzungen werden wir diese Inhalte umgehend
+    entfernen.
+  </p>
+
+  <h3>Haftung für Links</h3>
+
+  <p>
+    Unser Angebot enthält Links zu externen Webseiten Dritter, auf deren
+    Inhalte wir keinen Einfluss haben. Deshalb können wir für diese fremden
+    Inhalte auch keine Gewähr übernehmen. Für die Inhalte der verlinkten
+    Seiten ist stets der jeweilige Anbieter oder Betreiber der Seiten
+    verantwortlich. Die verlinkten Seiten wurden zum Zeitpunkt der Verlinkung
+    auf mögliche Rechtsverstöße überprüft. Rechtswidrige Inhalte waren zum
+    Zeitpunkt der Verlinkung nicht erkennbar. Eine permanente inhaltliche
+    Kontrolle der verlinkten Seiten ist jedoch ohne konkrete Anhaltspunkte
+    einer Rechtsverletzung nicht zumutbar. Bei Bekanntwerden von
+    Rechtsverletzungen werden wir derartige Links umgehend entfernen.
+  </p>
+
+  <h3>Urheberrecht</h3>
+
+  <p>
+    Die durch die Seitenbetreiber erstellten Inhalte und Werke auf diesen
+    Seiten unterliegen dem deutschen Urheberrecht. Die Vervielfältigung,
+    Bearbeitung, Verbreitung und jede Art der Verwertung außerhalb der Grenzen
+    des Urheberrechtes bedürfen der schriftlichen Zustimmung des jeweiligen
+    Autors bzw. Erstellers. Downloads und Kopien dieser Seite sind nur für den
+    privaten, nicht kommerziellen Gebrauch gestattet. Soweit die Inhalte auf
+    dieser Seite nicht vom Betreiber erstellt wurden, werden die Urheberrechte
+    Dritter beachtet. Insbesondere werden Inhalte Dritter als solche
+    gekennzeichnet. Sollten Sie trotzdem auf eine Urheberrechtsverletzung
+    aufmerksam werden, bitten wir um einen entsprechenden Hinweis. Bei
+    Bekanntwerden von Rechtsverletzungen werden wir derartige Inhalte umgehend
+    entfernen.
+  </p>
+
+  <h3>Datenschutz</h3>
+
+  <p>
+    Die Nutzung unserer Webseite ist in der Regel ohne Angabe
+    personenbezogener Daten möglich. Soweit auf unseren Seiten
+    personenbezogene Daten (beispielsweise Name, Anschrift oder
+    eMail-Adressen) erhoben werden, erfolgt dies, soweit möglich, stets auf
+    freiwilliger Basis. Diese Daten werden ohne Ihre ausdrückliche Zustimmung
+    nicht an Dritte weitergegeben. Wir weisen darauf hin, dass die
+    Datenübertragung im Internet (z.B. bei der Kommunikation per E-Mail)
+    Sicherheitslücken aufweisen kann. Ein lückenloser Schutz der Daten vor
+    dem Zugriff durch Dritte ist nicht möglich. Der Nutzung von im Rahmen der
+    Impressumspflicht veröffentlichten Kontaktdaten durch Dritte zur
+    Übersendung von nicht ausdrücklich angeforderter Werbung und
+    Informationsmaterialien wird hiermit ausdrücklich widersprochen. Die
+    Betreiber der Seiten behalten sich ausdrücklich rechtliche Schritte im
+    Falle der unverlangten Zusendung von Werbeinformationen, etwa durch
+    Spam-Mails, vor.
+  </p>
+
+  <hr/>
+
+  <footer>
+    <p>
+      <i>
+        Impressum vom
+        <a href="https://www.impressum-generator.de">impressum-generator.de</a>.
+      </i>
+    </p>
+  </footer>
+
+</body>
+
+</html>

--- a/frontend/src/Admin.tsx
+++ b/frontend/src/Admin.tsx
@@ -22,7 +22,7 @@ class Admin extends React.Component<AdminProps> {
   }
 
   render() {
-      return (
+    return (
       <>
         <h1>Warte Frei</h1>
         <div className="admin-view">
@@ -37,6 +37,9 @@ class Admin extends React.Component<AdminProps> {
             <QueueManagement />
           </aside>
         </div>
+        <footer className="admin-footer">
+          <a href={process.env.PUBLIC_URL + '/impressum.html'}>Impressum</a>
+        </footer>
       </>
     );
   }

--- a/frontend/src/patient/PatientWelcome.tsx
+++ b/frontend/src/patient/PatientWelcome.tsx
@@ -45,9 +45,8 @@ export function PatientWelcome() {
           className="welcome-patient-virus-logo"
           src={virusLogo}
           alt="Wir VS Virus Logo"/>
+        <a href={process.env.PUBLIC_URL + '/impressum.html'}>Impressum</a>
       </footer>
-  </div>
+    </div>
   );
 }
-
-

--- a/frontend/src/patient/QueueBoard.tsx
+++ b/frontend/src/patient/QueueBoard.tsx
@@ -52,6 +52,9 @@ export function QueueBoard(props: any) {
         )
       })}
     </div>
+    <footer className="queue-footer">
+      <a href={process.env.PUBLIC_URL + '/impressum.html'}>Impressum</a>
+    </footer>
     </>
   );
 }

--- a/frontend/src/styles/Admin.css
+++ b/frontend/src/styles/Admin.css
@@ -135,4 +135,10 @@ span.optional-star {
   min-height: 125px;
 }
 
-
+.admin-footer {
+  position: fixed;
+  text-align: center;
+  background-color: white;
+  width: 100%;
+  bottom: 0;
+}

--- a/frontend/src/styles/QueueBoard.css
+++ b/frontend/src/styles/QueueBoard.css
@@ -55,3 +55,11 @@
 .ticket-number {
   font-size: 2rem;
 }
+
+.queue-footer {
+  position: fixed;
+  text-align: center;
+  background-color: white;
+  width: 100%;
+  bottom: 0;
+}

--- a/frontend/src/styles/Welcome.css
+++ b/frontend/src/styles/Welcome.css
@@ -92,18 +92,24 @@
 }
 
 input:focus {
-    outline-width: 0;
+  outline-width: 0;
 }
 
 .welcome-patient-footer {
   display: flex;
+  align-items: center;
   justify-content: center;
   width: 100%;
   background: rgba(3, 3, 3, 0.4);
 }
 
+.welcome-patient-footer > a {
+  color: black
+}
+
 .welcome-patient-virus-logo {
   width: 240px;
+  margin-right: 32px;
 }
 
 


### PR DESCRIPTION
Adds the required legal notice ("Impressum") as a static HTML page. Links to it are added in footers of all three views (welcome, patient queue, and admin).

@ohaz: I have taken the content of your legal notice. It's pretty much copypasta. I just reduced it to the bare minimum of markup with very minor cosmetic adjustments (no CSS whatsoever). You should still have a look, after all, it's your personal information that gets shown, so I want your explicit approval.